### PR TITLE
Moved prettier into devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,9 +36,7 @@
     "@babel/preset-env": "^7.0.0-beta.34",
     "@babel/register": "^7.0.0-beta.34",
     "chai": "^4.1.2",
-    "mocha": "^7.1.1"
-  },
-  "dependencies": {
+    "mocha": "^7.1.1",
     "prettier": "^1.9.1"
   }
 }


### PR DESCRIPTION
`prettier` does not need to be a regular dependency as it is only used when developing